### PR TITLE
Add method jumping

### DIFF
--- a/autoload/jump_from_treesitter.vim
+++ b/autoload/jump_from_treesitter.vim
@@ -18,6 +18,9 @@ function! jump_from_treesitter#jump_to(token) abort
       call jump_from_treesitter#jump_to(klass)
     else
       echo 'No definition found for "'.a:token.'"'
+      if exists("*CocAction")
+        call CocAction('jumpDefinition')
+      end
     end
   end
 endfunction

--- a/autoload/jump_from_treesitter.vim
+++ b/autoload/jump_from_treesitter.vim
@@ -51,7 +51,10 @@ endfunction
 
 function! jump_from_treesitter#handle_results(results)
   if len(a:results) == 1
-    execute("edit ".a:results[0])
+    let bits = split(a:results[0], ":")
+    let path = bits[0]
+    let line_number = bits[1]
+    execute("edit +".line_number." ".path)
   else
     call fzf#run(
       \   fzf#wrap('files', fzf#vim#with_preview({

--- a/autoload/jump_from_treesitter.vim
+++ b/autoload/jump_from_treesitter.vim
@@ -23,7 +23,15 @@ function! jump_from_treesitter#jump_to(token) abort
 endfunction
 
 function! jump_from_treesitter#grep(token) abort
-  let output = execute('silent !rg "^[^\#]*class '.a:token.'(\s|$)" -l')
+  if tolower(a:token) ==# a:token
+    return jump_from_treesitter#grep_with('^[^\#]*def '.a:token.'(\s|$|\()')
+  else
+    return jump_from_treesitter#grep_with('^[^\#]*class '.a:token.'(\s|$)')
+  end
+endfunction
+
+function! jump_from_treesitter#grep_with(query) abort
+  let output = execute('silent !rg "'.a:query.'" --vimgrep')
   redraw!
   let lines = split(output, "\n")
   if len(lines) == 4 && lines[3] == "shell returned 1"

--- a/test/examples.rb
+++ b/test/examples.rb
@@ -1,4 +1,7 @@
 class Token
+  def method
+    # Example
+  end
 end
 
 class Module::Token

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -30,6 +30,13 @@ describe("jump-from-treesitter", () => {
       assert.equal(currentBufferPath, "test/examples.rb")
     }));
 
+  it("jumps to matched line number", () =>
+    withVim(async nvim => {
+      await nvim.commandOutput(`echo jump_from_treesitter#jump_to("method")`)
+      const currentLineNumber = await nvim.commandOutput(`echo line(".")`)
+      assert.equal(currentLineNumber, "2")
+    }));
+
   it("handles zero matches", () =>
     withVim(async nvim => {
       const result = await nvim.commandOutput(`call jump_from_treesitter#jump_to("F_oo")`)

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -19,6 +19,14 @@ describe("jump-from-treesitter", () => {
     withVim(async nvim => {
       await nvim.commandOutput(`echo jump_from_treesitter#jump_to("Module::Token")`)
       const currentBufferPath = await nvim.commandOutput(`echo expand("%")`)
+      console.log("foo", currentBufferPath)
+      assert.equal(currentBufferPath, "test/examples.rb")
+    }));
+
+  it("handles method matches", () =>
+    withVim(async nvim => {
+      await nvim.commandOutput(`echo jump_from_treesitter#jump_to("method")`)
+      const currentBufferPath = await nvim.commandOutput(`echo expand("%")`)
       assert.equal(currentBufferPath, "test/examples.rb")
     }));
 


### PR DESCRIPTION
- Wanted to add the ability to jump to methods (again, via basic static matching)
- Also jumps to the matching line number (now that that's more relevant)
- Falls back to `CocAction("jumpDefinition")` also